### PR TITLE
Refactor: OCR PDF 처리 속도 개선 

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,10 @@ from PIL import Image, UnidentifiedImageError
 
 
 MAX_FILE_SIZE = 10 * 1024 * 1024
-MAX_PDF_PAGES = 5
+MAX_PDF_PAGES = 3
+PDF_RENDER_SCALE = 1.5
+MAX_IMAGE_WIDTH = 1800
+MAX_IMAGE_HEIGHT = 1800
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".pdf"}
 
 app = FastAPI(title="bank-ocr")
@@ -45,6 +48,10 @@ def validate_filename(filename: str | None) -> str:
 
 def extract_lines_from_image_bytes(file_bytes: bytes) -> list[str]:
     image = Image.open(BytesIO(file_bytes)).convert("RGB")
+
+    if image.width > MAX_IMAGE_WIDTH or image.height > MAX_IMAGE_HEIGHT:
+        image.thumbnail((MAX_IMAGE_WIDTH, MAX_IMAGE_HEIGHT))
+
     results = reader.readtext(np.array(image))
     return [text.strip() for _, text, _ in results if text.strip()]
 
@@ -58,7 +65,9 @@ def extract_lines_from_pdf_bytes(file_bytes: bytes) -> list[str]:
 
             for page_index in range(page_count):
                 page = pdf_document.load_page(page_index)
-                pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                pixmap = page.get_pixmap(
+                    matrix=fitz.Matrix(PDF_RENDER_SCALE, PDF_RENDER_SCALE)
+                )
                 image_bytes = pixmap.tobytes("png")
                 lines.extend(extract_lines_from_image_bytes(image_bytes))
     except RuntimeError as exc:


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #3 

---

### 📝 작업 내용

- PDF OCR 처리 구간 성능 분석
- PDF 최대 처리 페이지 수를 3페이지로 제한
- PDF 렌더링 해상도 조정
- OCR 수행 전 대용량 이미지 리사이즈 처리 추가
- 개선 전/후 응답 시간 비교
---

### 📷 스크린샷 (선택)

<img width="422" height="283" alt="image" src="https://github.com/user-attachments/assets/cb67fcff-fd5a-4c77-8723-a5f86c30f9da" />

<img width="438" height="291" alt="image" src="https://github.com/user-attachments/assets/fa7e74fd-11d1-4757-958c-d3d62ce80f1f" />

측정 후
<img width="334" height="242" alt="image" src="https://github.com/user-attachments/assets/b2f7bb04-9ed2-4147-afe6-44caf307a613" />

<img width="349" height="215" alt="image" src="https://github.com/user-attachments/assets/2587f039-d2db-48b0-aee7-c07865343d80" />


---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
